### PR TITLE
Adding values function wrapper to API

### DIFF
--- a/src/clojure/flambo/api.clj
+++ b/src/clojure/flambo/api.clj
@@ -10,7 +10,7 @@
 ;; happily accepted!
 ;;
 (ns flambo.api
-  (:refer-clojure :exclude [fn map reduce first count take distinct filter group-by])
+  (:refer-clojure :exclude [fn map reduce first count take distinct filter group-by values])
   (:require [serializable.fn :as sfn]
             [clojure.tools.logging :as log]
             [flambo.function :refer [flat-map-function
@@ -163,6 +163,13 @@
   computed correctly in parallel."
   [rdd f]
   (.reduce rdd (function2 f)))
+
+(defn values
+  "Returns the values of a JavaPairRDD"
+  [rdd]
+  (-> rdd
+      (map-to-pair identity)
+      .values))
 
 (defn flat-map
   "Similar to `map`, but each input item can be mapped to 0 or more output items (so the

--- a/test/flambo/api_test.clj
+++ b/test/flambo/api_test.clj
@@ -233,6 +233,17 @@
                              ["key3" 13]])
            (f/count-by-value)) => {["key1" 11] 2, ["key2" 12] 2, ["key3" 13] 1})
 
+       (fact
+       "values returns the values (V) of a hashmap of (K, V) pairs"
+       (-> (f/parallelize c [["key1" 11]
+                             ["key1" 11]
+                             ["key2" 12]
+                             ["key2" 12]
+                             ["key3" 13]])
+           (f/values)
+           (f/collect)
+           vec) => [11, 11, 12, 12, 13])
+
       (fact
         "foreach runs a function on each element of the RDD, returns nil; this is usually done for side effcts"
         (-> (f/parallelize c [1 2 3 4 5])


### PR DESCRIPTION
This enable to easily convert a JavaPairRDD -> JavaRDD based on the values of the pairs. Keys are ignored.

I needed to add this since elasticsearch-hadoop lib for Spark returns JavaPairRDD by default.

Thanks!
