### PR TITLE
Another take on serialization of functions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,6 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/tools.logging "0.2.6"]
-                 [yieldbot/serializable-fn "0.0.6"
-                  :exclusions [com.twitter/chill-java]]
                  [com.twitter/carbonite "1.4.0"
                   :exclusions [com.twitter/chill-java]]
                  [com.twitter/chill_2.10 "0.3.6"
@@ -17,8 +15,8 @@
               :plugins [[lein-midje "3.1.3"]
                         [lein-marginalia "0.8.0"]
                         [codox "0.8.9"]]
-              ;; so gen-class stuff works in the repl
-              :aot [flambo.function
+              :aot [flambo.api
+                    flambo.function
                     flambo.example.tfidf]}
              :provided
              {:dependencies
@@ -26,6 +24,10 @@
                [org.apache.spark/spark-streaming_2.10 "1.1.0"]
                [org.apache.spark/spark-streaming-kafka_2.10 "1.1.0"]
                [org.apache.spark/spark-sql_2.10 "1.1.0"]]}
+             :test
+             {:aot [flambo.api
+                    flambo.function
+                    flambo.api-test]}
              :uberjar
              {:aot :all}}
   :source-paths ["src/clojure"]

--- a/src/clojure/flambo/api.clj
+++ b/src/clojure/flambo/api.clj
@@ -11,8 +11,7 @@
 ;;
 (ns flambo.api
   (:refer-clojure :exclude [fn map reduce first count take distinct filter group-by])
-  (:require [serializable.fn :as sfn]
-            [clojure.tools.logging :as log]
+  (:require [clojure.tools.logging :as log]
             [flambo.function :refer [flat-map-function
                                      flat-map-function2
                                      function
@@ -29,9 +28,7 @@
            (java.util Comparator)
            (org.apache.spark.api.java JavaSparkContext StorageLevels)
            org.apache.spark.api.java.JavaRDD
-           (org.apache.spark.rdd PartitionwiseSampledRDD)
-           (flambo.function Function Function2 Function3 VoidFunction FlatMapFunction
-                            PairFunction PairFlatMapFunction)))
+           (org.apache.spark.rdd PartitionwiseSampledRDD)))
 
 ;; flambo makes extensive use of kryo to serialize and deserialize clojure functions
 ;; and data structures. Here we ensure that these properties are set so they are inhereted
@@ -55,7 +52,7 @@
 
 (defmacro fn
   [& body]
-  `(sfn/fn ~@body))
+  `(clojure.core/fn ~@body))
 
 (defmacro defsparkfn
   [name & body]

--- a/src/clojure/flambo/function.clj
+++ b/src/clojure/flambo/function.clj
@@ -1,74 +1,15 @@
-(ns flambo.function
-  (:require [serializable.fn :as sfn]
-            [flambo.utils :as u]
-            [flambo.kryo :as kryo]
-            [clojure.tools.logging :as log])
-  (:import [scala Tuple2]))
-
-(defn- serfn? [f]
-  (= (type f) :serializable.fn/serializable-fn))
-
-(def serialize-fn sfn/serialize)
-(def deserialize-fn (memoize sfn/deserialize))
-(def array-of-bytes-type (Class/forName "[B"))
-
-;; ## Generic
-(defn -init
-  "Save the function f in state"
-  [f]
-  [[] f])
-
-(defn -call [this & xs]
-  (let [fn-or-serfn (.state this)
-        f (if (instance? array-of-bytes-type fn-or-serfn)
-            (binding [sfn/*deserialize* kryo/deserialize]
-              (deserialize-fn fn-or-serfn))
-            fn-or-serfn)]
-    (log/trace "CLASS" (type this))
-    (log/trace "META" (meta f))
-    (log/trace "XS" xs)
-    (apply f xs)))
-
-;; ## Functions
-(defn mk-sym
-  [fmt sym-name]
-  (symbol (format fmt sym-name)))
+(ns flambo.function)
 
 (defmacro gen-function
   [clazz wrapper-name]
-  (let [new-class-sym (mk-sym "flambo.function.%s" clazz)
-        prefix-sym (mk-sym "%s-" clazz)]
-    `(do
-       (def ~(mk-sym "%s-init" clazz) -init)
-       (def ~(mk-sym "%s-call" clazz) -call)
-       (gen-class
-        :name ~new-class-sym
-        :implements [~(mk-sym "org.apache.spark.api.java.function.%s" clazz)]
-        :prefix ~prefix-sym
-        :init ~'init
-        :state ~'state
-        :constructors {[Object] []})
-       (defn ~wrapper-name [f#]
-         (new ~new-class-sym
-              (if (serfn? f#) (binding [sfn/*serialize* kryo/serialize]
-                                (serialize-fn f#)) f#))))))
+  `(defn ~wrapper-name [f#]
+     (new ~(symbol (str "flambo.function." clazz)) f#)))
 
-(gen-function Function function)
-(gen-function Function2 function2)
-(gen-function Function3 function3)
-(gen-function VoidFunction void-function)
-(gen-function FlatMapFunction flat-map-function)
-(gen-function FlatMapFunction2 flat-map-function2)
-(gen-function PairFlatMapFunction pair-flat-map-function)
-(gen-function PairFunction pair-function)
-
-;; Replaces the PairFunction-call and PairFlatMapFunction-call defined by the gen-function macro.
-(defn PairFunction-call [this x]
-  (let [[a b] (-call this x)]
-    (Tuple2. a b)))
-
-(defn PairFlatMapFunction-call [this x]
-  (let [ret (-call this x)]
-    (for [v ret
-          :let [[a b] v]]
-      (Tuple2. a b))))
+(gen-function FlamboFunction function)
+(gen-function FlamboFunction2 function2)
+(gen-function FlamboFunction3 function3)
+(gen-function FlamboVoidFunction void-function)
+(gen-function FlamboFlatMapFunction flat-map-function)
+(gen-function FlamboFlatMapFunction2 flat-map-function2)
+(gen-function FlamboPairFlatMapFunction pair-flat-map-function)
+(gen-function FlamboPairFunction pair-function)

--- a/src/java/flambo/function/FlamboFlatMapFunction.java
+++ b/src/java/flambo/function/FlamboFlatMapFunction.java
@@ -1,0 +1,36 @@
+package flambo.function;
+
+import java.lang.ClassNotFoundException;
+import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.ObjectInputStream;
+
+import clojure.lang.AFunction;
+
+import flambo.function.Utils;
+
+import org.apache.spark.api.java.function.FlatMapFunction;
+
+public class FlamboFlatMapFunction implements FlatMapFunction, Serializable {
+  
+  private AFunction f;
+  
+  public FlamboFlatMapFunction() {}
+  
+  public FlamboFlatMapFunction(AFunction func) {
+    f = func;
+  }
+  
+  public Iterable<Object> call(Object v1) throws Exception {
+    return (Iterable<Object>) f.invoke(v1);
+  }
+  
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    Utils.writeAFunction(out, f);
+  }
+  
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    f = Utils.readAFunction(in);
+  }
+}

--- a/src/java/flambo/function/FlamboFlatMapFunction2.java
+++ b/src/java/flambo/function/FlamboFlatMapFunction2.java
@@ -1,0 +1,36 @@
+package flambo.function;
+
+import java.lang.ClassNotFoundException;
+import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.ObjectInputStream;
+
+import clojure.lang.AFunction;
+
+import flambo.function.Utils;
+
+import org.apache.spark.api.java.function.FlatMapFunction2;
+
+public class FlamboFlatMapFunction2 implements FlatMapFunction2, Serializable {
+  
+  private AFunction f;
+  
+  public FlamboFlatMapFunction2() {}
+  
+  public FlamboFlatMapFunction2(AFunction func) {
+    f = func;
+  }
+  
+  public Iterable<Object> call(Object v1, Object v2) throws Exception {
+    return (Iterable<Object>) f.invoke(v1, v2);
+  }
+  
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    Utils.writeAFunction(out, f);
+  }
+  
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    f = Utils.readAFunction(in);
+  }
+}

--- a/src/java/flambo/function/FlamboFunction.java
+++ b/src/java/flambo/function/FlamboFunction.java
@@ -1,0 +1,36 @@
+package flambo.function;
+
+import java.lang.ClassNotFoundException;
+import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.ObjectInputStream;
+
+import clojure.lang.AFunction;
+
+import flambo.function.Utils;
+
+import org.apache.spark.api.java.function.Function;
+
+public class FlamboFunction implements Function, Serializable {
+  
+  private AFunction f;
+  
+  public FlamboFunction() {}
+  
+  public FlamboFunction(AFunction func) {
+    f = func;
+  }
+  
+  public Object call(Object v1) throws Exception {
+    return f.invoke(v1);
+  }
+  
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    Utils.writeAFunction(out, f);
+  }
+  
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    f = Utils.readAFunction(in);
+  }
+}

--- a/src/java/flambo/function/FlamboFunction2.java
+++ b/src/java/flambo/function/FlamboFunction2.java
@@ -1,0 +1,36 @@
+package flambo.function;
+
+import java.lang.ClassNotFoundException;
+import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.ObjectInputStream;
+
+import clojure.lang.AFunction;
+
+import flambo.function.Utils;
+
+import org.apache.spark.api.java.function.Function2;
+
+public class FlamboFunction2 implements Function2, Serializable {
+  
+  private AFunction f;
+  
+  public FlamboFunction2() {}
+  
+  public FlamboFunction2(AFunction func) {
+    f = func;
+  }
+  
+  public Object call(Object v1, Object v2) throws Exception {
+    return f.invoke(v1, v2);
+  }
+  
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    Utils.writeAFunction(out, f);
+  }
+  
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    f = Utils.readAFunction(in);
+  }
+}

--- a/src/java/flambo/function/FlamboFunction3.java
+++ b/src/java/flambo/function/FlamboFunction3.java
@@ -1,0 +1,36 @@
+package flambo.function;
+
+import java.lang.ClassNotFoundException;
+import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.ObjectInputStream;
+
+import clojure.lang.AFunction;
+
+import flambo.function.Utils;
+
+import org.apache.spark.api.java.function.Function3;
+
+public class FlamboFunction3 implements Function3, Serializable {
+  
+  private AFunction f;
+  
+  public FlamboFunction3() {}
+  
+  public FlamboFunction3(AFunction func) {
+    f = func;
+  }
+  
+  public Object call(Object v1, Object v2, Object v3) throws Exception {
+    return f.invoke(v1, v2, v3);
+  }
+  
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    Utils.writeAFunction(out, f);
+  }
+  
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    f = Utils.readAFunction(in);
+  }
+}

--- a/src/java/flambo/function/FlamboPairFlatMapFunction.java
+++ b/src/java/flambo/function/FlamboPairFlatMapFunction.java
@@ -1,0 +1,62 @@
+package flambo.function;
+
+import java.lang.Iterable;
+import java.util.Iterator;
+import java.lang.ClassNotFoundException;
+import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.ObjectInputStream;
+
+import clojure.lang.AFunction;
+import clojure.lang.Indexed;
+
+import flambo.function.Utils;
+
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+
+import scala.Tuple2;
+
+public class FlamboPairFlatMapFunction implements PairFlatMapFunction, Serializable {
+  
+  private AFunction f;
+  
+  public FlamboPairFlatMapFunction() {}
+  
+  public FlamboPairFlatMapFunction(AFunction func) {
+    f = func;
+  }
+  
+  public Iterable<Tuple2<Object, Object>> call(Object v1) throws Exception {
+    final Iterable<Indexed> values = (Iterable<Indexed>) f.invoke(v1);
+    final Iterator<Indexed> iter = values.iterator();
+    
+    // Transforms every Indexed objects to Tuple2
+    return new Iterable<Tuple2<Object,Object>>() {
+      public Iterator<Tuple2<Object,Object>> iterator() {
+        return new Iterator() {
+          public boolean hasNext() {
+            return iter.hasNext();
+          }
+          
+          public Tuple2 next() {
+            Indexed v = iter.next();
+            return new Tuple2(v.nth(0), v.nth(1));
+          }
+          
+          public void remove(){
+            iter.remove();
+          }
+        };
+      }
+    };
+  }
+  
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    Utils.writeAFunction(out, f);
+  }
+  
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    f = Utils.readAFunction(in);
+  }
+}

--- a/src/java/flambo/function/FlamboPairFunction.java
+++ b/src/java/flambo/function/FlamboPairFunction.java
@@ -1,0 +1,40 @@
+package flambo.function;
+
+import java.lang.ClassNotFoundException;
+import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.ObjectInputStream;
+
+import clojure.lang.AFunction;
+import clojure.lang.Indexed;
+
+import flambo.function.Utils;
+
+import org.apache.spark.api.java.function.PairFunction;
+
+import scala.Tuple2;
+
+public class FlamboPairFunction implements PairFunction, Serializable {
+  
+  private AFunction f;
+  
+  public FlamboPairFunction() {}
+  
+  public FlamboPairFunction(AFunction func) {
+    f = func;
+  }
+  
+  public Tuple2<Object, Object> call(Object v1) throws Exception {
+    Indexed v = (Indexed) f.invoke(v1);
+    return new Tuple2(v.nth(0), v.nth(1));
+  }
+  
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    Utils.writeAFunction(out, f);
+  }
+  
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    f = Utils.readAFunction(in);
+  }
+}

--- a/src/java/flambo/function/FlamboVoidFunction.java
+++ b/src/java/flambo/function/FlamboVoidFunction.java
@@ -1,0 +1,36 @@
+package flambo.function;
+
+import java.lang.ClassNotFoundException;
+import java.io.Serializable;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.ObjectInputStream;
+
+import clojure.lang.AFunction;
+
+import flambo.function.Utils;
+
+import org.apache.spark.api.java.function.VoidFunction;
+
+public class FlamboVoidFunction implements VoidFunction, Serializable {
+  
+  private AFunction f;
+  
+  public FlamboVoidFunction() {}
+  
+  public FlamboVoidFunction(AFunction func) {
+    f = func;
+  }
+  
+  public void call(Object v1) throws Exception {
+    f.invoke(v1);
+  }
+  
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    Utils.writeAFunction(out, f);
+  }
+  
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    f = Utils.readAFunction(in);
+  }
+}

--- a/src/java/flambo/function/Utils.java
+++ b/src/java/flambo/function/Utils.java
@@ -1,0 +1,36 @@
+package flambo.function;
+
+import java.lang.ClassNotFoundException;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.ObjectInputStream;
+
+import clojure.lang.RT;
+import clojure.lang.Var;
+import clojure.lang.AFunction;
+
+public class Utils {
+  
+  static final Var require = RT.var("clojure.core", "require");
+  static final Var symbol = RT.var("clojure.core", "symbol");
+  
+  private Utils() {}
+  
+  public static void requireNamespace(String namespace) {
+    require.invoke(symbol.invoke(namespace));
+  }
+  
+  public static void writeAFunction(ObjectOutputStream out, AFunction f) throws IOException {
+    out.writeObject(f.getClass().getName());
+    out.writeObject(f);
+  }
+  
+  public static AFunction readAFunction(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    String clazz = (String) in.readObject();
+    String namespace = clazz.split("\\$")[0];
+    
+    requireNamespace(namespace);
+    
+    return (AFunction) in.readObject();
+  }
+}

--- a/test/flambo/api_test.clj
+++ b/test/flambo/api_test.clj
@@ -1,124 +1,86 @@
 (ns flambo.api-test
-  (:use midje.sweet)
+  (:use clojure.test)
   (:require [flambo.api :as f]
             [flambo.conf :as conf]))
 
-(facts
- "about spark-context"
- (let [conf (-> (conf/spark-conf)
-                (conf/master "local[*]")
-                (conf/app-name "api-test"))]
-   (f/with-context c conf
-     (fact
-      "gives us a JavaSparkContext"
-      (class c) => org.apache.spark.api.java.JavaSparkContext)
-
-     (fact
-      "creates a JavaRDD"
-      (class (f/parallelize c [1 2 3 4 5])) => org.apache.spark.api.java.JavaRDD)
-
-     (fact
-      "round-trips a clojure vector"
-      (-> (f/parallelize c [1 2 3 4 5]) f/collect vec) => (just [1 2 3 4 5])))))
-
-(facts
- "about serializable functions"
-
- (let [myfn (f/fn [x] (* 2 x))]
-   (fact
-    "inline op returns a serializable fn"
-    (type myfn) => :serializable.fn/serializable-fn)
-
-   (fact
-    "we can serialize it to a byte-array"
-    (class (serializable.fn/serialize myfn)) => (Class/forName "[B"))
-
-   (fact
-    "it round-trips back to a serializable fn"
-    (type (-> myfn serializable.fn/serialize serializable.fn/deserialize)) => :serializable.fn/serializable-fn)))
-
-(facts
- "about untupling"
-
- (fact
-  "untuple returns a 2 vector"
-  (let [tuple2 (scala.Tuple2. 1 "hi")]
-    (f/untuple tuple2) => [1 "hi"]))
-
- (fact
-  "double untuple returns a vector with a key and a 2 vector value"
-  (let [double-tuple2 (scala.Tuple2. 1 (scala.Tuple2. 2 "hi"))]
-    (f/double-untuple double-tuple2) => [1 [2 "hi"]])))
-
-(facts
-  "about transformations"
-
+(deftest spark-context
   (let [conf (-> (conf/spark-conf)
                  (conf/master "local[*]")
                  (conf/app-name "api-test"))]
     (f/with-context c conf
-      (fact
-        "map returns an RDD formed by passing each element of the source RDD through a function"
-        (-> (f/parallelize c [1 2 3 4 5])
-            (f/map (f/fn [x] (* 2 x)))
-            f/collect
-            vec) => [2 4 6 8 10])
+      (testing "gives us a JavaSparkContext"
+        (is (= (class c) org.apache.spark.api.java.JavaSparkContext)))
 
-      (fact
-        "map-to-pair returns an RDD of (K, V) pairs formed by passing each element of the source
-        RDD through a pair function"
-        (-> (f/parallelize c ["a" "b" "c" "d"])
-            (f/map-to-pair (f/fn [x] [x 1]))
-            (f/map f/untuple)
-            f/collect
-            vec) => [["a" 1] ["b" 1] ["c" 1] ["d" 1]])
+      (testing "creates a JavaRDD"
+        (is (= (class (f/parallelize c [1 2 3 4 5]))
+               org.apache.spark.api.java.JavaRDD)))
 
-      (fact
-        "reduce-by-key returns an RDD of (K, V) when called on an RDD of (K, V) pairs"
-        (-> (f/parallelize c [["key1" 1]
-                              ["key1" 2]
-                              ["key2" 3]
-                              ["key2" 4]
-                              ["key3" 5]])
-            (f/reduce-by-key (f/fn [x y] (+ x y)))
-            f/collect
-            vec) => (contains #{["key1" 3] ["key2" 7] ["key3" 5]}))
+      (testing "round-trips a clojure vector"
+        (is (= (-> (f/parallelize c [1 2 3 4 5]) f/collect vec)
+               [1 2 3 4 5]))))))
 
-      (fact
-        "similar to map, but each input item can be mapped to 0 or more output items;
-        mapping function must therefore return a sequence rather than a single item"
-        (-> (f/parallelize c [["Four score and seven years ago our fathers"]
-                              ["brought forth on this continent a new nation"]])
-            (f/flat-map (f/fn [x] (clojure.string/split (first x) #" ")))
-            f/collect
-            vec) => ["Four" "score" "and" "seven" "years" "ago" "our" "fathers" "brought" "forth" "on" "this" "continent" "a" "new" "nation"])
+(deftest untupling
+  (testing "untuple returns a 2 vector"
+    (let [tuple2 (scala.Tuple2. 1 "hi")]
+      (is (= (f/untuple tuple2) [1 "hi"]))))
 
-      (fact
-        "filter returns an RDD formed by selecting those elements of the source on which func returns true"
-        (-> (f/parallelize c [1 2 3 4 5 6])
-            (f/filter (f/fn [x] (even? x)))
-            f/collect
-            vec) => [2 4 6])
+  (testing "double untuple returns a vector with a key and a 2 vector value"
+    (let [double-tuple2 (scala.Tuple2. 1 (scala.Tuple2. 2 "hi"))]
+      (is (= (f/double-untuple double-tuple2) [1 [2 "hi"]])))))
 
-      (fact
-        "join returns an RDD of (K, (V, W)) pairs with all pairs of elements of each key when called on RDDs of type (K, V) and (K, W)"
-        (let [LDATA (f/parallelize c [["key1" [2]]
-                                      ["key2" [3]]
-                                      ["key3" [5]]
-                                      ["key4" [1]]
-                                      ["key5" [2]]])
-              RDATA (f/parallelize c [["key1" [22]]
-                                      ["key3" [33]]
-                                      ["key4" [44]]])
-              ]
-          (-> (f/join LDATA RDATA)
-              f/collect
-              vec)) => (just [["key3" [[5] [33]]]
-                              ["key4" [[1] [44]]]
-                              ["key1" [[2] [22]]]] :in-any-order))
+(deftest transformations
+  (let [conf (-> (conf/spark-conf)
+                 (conf/master "local[*]")
+                 (conf/app-name "api-test"))]
+    (f/with-context c conf
+      (testing "map returns an RDD formed by passing each element of the source RDD through a function"
+        (is (= (-> (f/parallelize c [1 2 3 4 5])
+                   (f/map (f/fn [x] (* 2 x)))
+                   f/collect
+                   vec)
+               [2 4 6 8 10])))
 
-      (fact
-        "left-outer-join returns an RDD of (K, (V, W)) when called on RDDs of type (K, V) and (K, W)"
+      (testing "map-to-pair returns an RDD of (K, V) pairs formed by passing each element of the source
+                RDD through a pair function"
+        (is (= (-> (f/parallelize c ["a" "b" "c" "d"])
+                   (f/map-to-pair (f/fn [x] [x 1]))
+                   (f/map f/untuple)
+                   f/collect
+                   vec)
+                [["a" 1] ["b" 1] ["c" 1] ["d" 1]])))
+
+      (testing "reduce-by-key returns an RDD of (K, V) when called on an RDD of (K, V) pairs"
+        (is (= (-> (f/parallelize c [["key1" 1]
+                                     ["key1" 2]
+                                     ["key2" 3]
+                                     ["key2" 4]
+                                     ["key3" 5]])
+                   (f/reduce-by-key (f/fn [x y] (+ x y)))
+                   f/collect
+                   vec)
+                [["key3" 5] ["key1" 3] ["key2" 7]])))
+
+      (testing "similar to map, but each input item can be mapped to 0 or more output items;
+                mapping function must therefore return a sequence rather than a single item"
+        (is (= (-> (f/parallelize c [["Four score and seven years ago our fathers"]
+                                     ["brought forth on this continent a new nation"]])
+                   (f/flat-map (f/fn [x] (clojure.string/split (first x) #" ")))
+                   f/collect
+                   vec)
+               ["Four" "score" "and" "seven" "years" "ago" "our"
+                "fathers" "brought" "forth" "on" "this" "continent"
+                "a" "new" "nation"])))
+
+      (testing "filter returns an RDD formed by selecting those elements of the source on
+                which func returns true"
+        (is (= (-> (f/parallelize c [1 2 3 4 5 6])
+                   (f/filter (f/fn [x] (even? x)))
+                   f/collect
+                   vec)
+               [2 4 6])))
+
+      (testing "join returns an RDD of (K, (V, W)) pairs with all pairs of elements of each
+                key when called on RDDs of type (K, V) and (K, W)"
         (let [LDATA (f/parallelize c [["key1" [2]]
                                       ["key2" [3]]
                                       ["key3" [5]]
@@ -127,169 +89,186 @@
               RDATA (f/parallelize c [["key1" [22]]
                                       ["key3" [33]]
                                       ["key4" [44]]])]
-          (-> (f/left-outer-join LDATA RDATA)
-              f/collect
-              vec)) => (just [["key3" [[5] [33]]]
-                              ["key4" [[1] [44]]]
-                              ["key5" [[2] nil]]
-                              ["key1" [[2] [22]]]
-                              ["key2" [[3] nil]]] :in-any-order))
+          (is (= (-> (f/join LDATA RDATA)
+                     f/collect
+                     vec))
+                 [["key3" [[5] [33]]]
+                  ["key4" [[1] [44]]]
+                  ["key1" [[2] [22]]]])))
 
-      (fact
-        "sample returns a fraction of the RDD, with/without replacement,
-        using a given random number generator seed"
-        (-> (f/parallelize c [0 1 2 3 4 5 6 7 8 9])
-            (f/sample false 0.1 2)
-            f/collect
-            vec) => [6])
+      (testing "left-outer-join returns an RDD of (K, (V, W))
+                when called on RDDs of type (K, V) and (K, W)"
+        (let [LDATA (f/parallelize c [["key1" [2]]
+                                      ["key2" [3]]
+                                      ["key3" [5]]
+                                      ["key4" [1]]
+                                      ["key5" [2]]])
+              RDATA (f/parallelize c [["key1" [22]]
+                                      ["key3" [33]]
+                                      ["key4" [44]]])]
+          (is (= (-> (f/left-outer-join LDATA RDATA)
+                     f/collect
+                     vec)
+                 [["key3" [[5] [33]]]
+                  ["key4" [[1] [44]]]
+                  ["key5" [[2] nil]]
+                  ["key1" [[2] [22]]]
+                  ["key2" [[3] nil]]]))))
 
-      (fact
-        "combine-by-key returns an RDD by combining the elements for each key using a custom
-        set of aggregation functions"
-        (-> (f/parallelize c [["key1" 1]
-                              ["key2" 1]
-                              ["key1" 1]])
-            (f/combine-by-key identity + +)
-            f/collect
-            vec) => (just [["key1" 2] ["key2" 1]] :in-any-order))
+      (testing "sample returns a fraction of the RDD, with/without replacement,
+                using a given random number generator seed"
+        (is (= (-> (f/parallelize c [0 1 2 3 4 5 6 7 8 9])
+                   (f/sample false 0.1 2)
+                   f/collect
+                   vec)
+                [6])))
 
-      (fact
-        "sort-by-key returns an RDD of (K, V) pairs sorted by keys in asc or desc order"
-        (-> (f/parallelize c [[2 "aa"]
-                              [5 "bb"]
-                              [3 "cc"]
-                              [1 "dd"]])
-            (f/sort-by-key compare false)
-            f/collect
-            vec) => [[5 "bb"] [3 "cc"] [2 "aa"] [1 "dd"]])
+      (testing "combine-by-key returns an RDD by combining the elements for each key using a custom
+                set of aggregation functions"
+        (is (= (-> (f/parallelize c [["key1" 1]
+                                     ["key2" 1]
+                                     ["key1" 1]])
+                   (f/combine-by-key identity + +)
+                   f/collect
+                   vec)
+               [["key1" 2] ["key2" 1]])))
 
-      (fact
-        "coalesce"
-        (-> (f/parallelize c [1 2 3 4 5])
-            (f/coalesce 1)
-            f/collect
-            vec) => [1 2 3 4 5])
+      (testing "sort-by-key returns an RDD of (K, V) pairs sorted by keys in asc or desc order"
+        (is (= (-> (f/parallelize c [[2 "aa"]
+                                     [5 "bb"]
+                                     [3 "cc"]
+                                     [1 "dd"]])
+                   (f/sort-by-key compare false)
+                   f/collect
+                   vec)
+               [[5 "bb"] [3 "cc"] [2 "aa"] [1 "dd"]])))
 
-      (fact
-        "group-by returns an RDD of items grouped by the grouping function"
-        (-> (f/parallelize c [1 1 2 3 5 8])
-            (f/group-by (f/fn [x] (mod x 2)))
-            f/collect
-            vec) => (just [[0 [2 8]] [1 [1 1 3 5]]] :in-any-order))
+      (testing "coalesce"
+        (is (= (-> (f/parallelize c [1 2 3 4 5])
+                   (f/coalesce 1)
+                   f/collect
+                   vec)
+               [1 2 3 4 5])))
 
-      (fact
-        "group-by-key"
-        (-> (f/parallelize c [["key1" 1]
-                              ["key1" 2]
-                              ["key2" 3]
-                              ["key2" 4]
-                              ["key3" 5]])
-            f/group-by-key
-            f/collect
-            vec) => (just [["key3" [5]] ["key1" [1 2]] ["key2" [3 4]]] :in-any-order))
+      (testing "group-by returns an RDD of items grouped by the grouping function"
+        (is (= (-> (f/parallelize c [1 1 2 3 5 8])
+                   (f/group-by (f/fn [x] (mod x 2)))
+                   f/collect
+                   vec)
+               [[0 [2 8]] [1 [1 1 3 5]]])))
 
-      (fact
-        "flat-map-to-pair"
-        (-> (f/parallelize c [["Four score and seven"]
-                              ["years ago"]])
-            (f/flat-map-to-pair (f/fn [x] (map (fn [y] [y 1])
-                                               (clojure.string/split (first x) #" "))))
-            (f/map f/untuple)
-            f/collect
-            vec) => [["Four" 1] ["score" 1] ["and" 1] ["seven" 1] ["years" 1] ["ago" 1]])
+      (testing "group-by-key"
+        (is (= (-> (f/parallelize c [["key1" 1]
+                                     ["key1" 2]
+                                     ["key2" 3]
+                                     ["key2" 4]
+                                     ["key3" 5]])
+                   f/group-by-key
+                   f/collect
+                   vec)
+               [["key3" [5]] ["key1" [1 2]] ["key2" [3 4]]])))
 
-      (future-fact "repartition returns a new RDD with exactly n partitions")
+      (testing "flat-map-to-pair"
+        (is (= (-> (f/parallelize c [["Four score and seven"]
+                                     ["years ago"]])
+                   (f/flat-map-to-pair (f/fn [x] (map (fn [y] [y 1])
+                                                      (clojure.string/split (first x) #" "))))
+                   (f/map f/untuple)
+                   f/collect
+                   vec)
+               [["Four" 1] ["score" 1] ["and" 1] ["seven" 1] ["years" 1] ["ago" 1]])))
 
-      )))
+      (testing "repartition returns a new RDD with exactly n partitions"))))
 
-(facts
-  "about actions"
-
+(deftest actions
   (let [conf (-> (conf/spark-conf)
                  (conf/master "local[*]")
                  (conf/app-name "api-test"))]
     (f/with-context c conf
-      (fact
-        "aggregates elements of RDD using a function that takes two arguments and returns one,
-        return type is a value"
-        (-> (f/parallelize c [1 2 3 4 5])
-            (f/reduce (f/fn [x y] (+ x y)))) => 15)
+      (testing "aggregates elements of RDD using a function that takes two arguments and returns one,
+                return type is a value"
+        (is (= (-> (f/parallelize c [1 2 3 4 5])
+                   (f/reduce (f/fn [x y] (+ x y))))
+               15)))
 
-      (fact
-        "count-by-key returns a hashmap of (K, int) pairs with the count of each key; only available on RDDs of type (K, V)"
-        (-> (f/parallelize c [["key1" 1]
-                              ["key1" 2]
-                              ["key2" 3]
-                              ["key2" 4]
-                              ["key3" 5]])
-            (f/count-by-key)) => {"key1" 2 "key2" 2 "key3" 1})
+      (testing "count-by-key returns a hashmap of (K, int) pairs with the count of each key;
+                only available on RDDs of type (K, V)"
+        (is (= (-> (f/parallelize c [["key1" 1]
+                                     ["key1" 2]
+                                     ["key2" 3]
+                                     ["key2" 4]
+                                     ["key3" 5]])
+                   (f/count-by-key))
+               {"key1" 2 "key2" 2 "key3" 1})))
 
-      (fact
-       "count-by-value returns a hashmap of (V, int) pairs with the count of each value"
-       (-> (f/parallelize c [["key1" 11]
-                             ["key1" 11]
-                             ["key2" 12]
-                             ["key2" 12]
-                             ["key3" 13]])
-           (f/count-by-value)) => {["key1" 11] 2, ["key2" 12] 2, ["key3" 13] 1})
+      (testing "count-by-value returns a hashmap of (V, int) pairs with the count of each value"
+        (is (= (-> (f/parallelize c [["key1" 11]
+                                     ["key1" 11]
+                                     ["key2" 12]
+                                     ["key2" 12]
+                                     ["key3" 13]])
+                   (f/count-by-value))
+               {["key1" 11] 2, ["key2" 12] 2, ["key3" 13] 1})))
 
-      (fact
-        "foreach runs a function on each element of the RDD, returns nil; this is usually done for side effcts"
-        (-> (f/parallelize c [1 2 3 4 5])
-            (f/foreach (f/fn [x] x))) => nil)
+      (testing "foreach runs a function on each element of the RDD, returns nil;
+                this is usually done for side effcts"
+        (is (= (-> (f/parallelize c [1 2 3 4 5])
+                   (f/foreach (f/fn [x] x)))
+               nil)))
 
-      (fact
-        "fold returns aggregate each partition, and then the results for all the partitions,
-        using a given associative function and a neutral 'zero value'"
-        (-> (f/parallelize c [1 2 3 4 5])
-            (f/fold 0 (f/fn [x y] (+ x y)))) => 15)
+      (testing "fold returns aggregate each partition, and then the results for all the partitions,
+                using a given associative function and a neutral 'zero value'"
+        (is (= (-> (f/parallelize c [1 2 3 4 5])
+                   (f/fold 0 (f/fn [x y] (+ x y))))
+               15)))
 
-      (fact
-        "first returns the first element of an RDD"
-        (-> (f/parallelize c [1 2 3 4 5])
-            f/first) => 1)
+      (testing "first returns the first element of an RDD"
+        (is (= (-> (f/parallelize c [1 2 3 4 5])
+                   f/first)
+               1)))
 
-      (fact
-        "count return the number of elements in an RDD"
-        (-> (f/parallelize c [["a" 1] ["b" 2] ["c" 3] ["d" 4] ["e" 5]])
-            f/count) => 5)
+      (testing "count return the number of elements in an RDD"
+        (is (= (-> (f/parallelize c [["a" 1] ["b" 2] ["c" 3] ["d" 4] ["e" 5]])
+                   f/count)
+               5)))
 
-      (fact
-        "collect returns all elements of the RDD as an array at the driver program"
-        (-> (f/parallelize c [[1] [2] [3] [4] [5]])
-            f/collect
-            vec) => [[1] [2] [3] [4] [5]])
+      (testing "collect returns all elements of the RDD as an array at the driver program"
+        (is (= (-> (f/parallelize c [[1] [2] [3] [4] [5]])
+                   f/collect
+                   vec)
+               [[1] [2] [3] [4] [5]])))
 
-      (fact
-       "distinct returns distinct elements of an RDD"
-       (-> (f/parallelize c [1 2 1 3 4 5 4])
-           f/distinct
-           f/collect
-           vec) => (contains #{1 2 3 4 5}))
+      (testing "distinct returns distinct elements of an RDD"
+        (is (= (-> (f/parallelize c [1 2 1 3 4 5 4])
+                   f/distinct
+                   f/collect
+                   vec
+                   sort)
+               [1 2 3 4 5])))
 
-      (fact
-       "distinct returns distinct elements of an RDD with the given number of partitions"
-       (-> (f/parallelize c [1 2 1 3 4 5 4])
-           (f/distinct 2)
-           f/collect
-           vec) => (contains #{1 2 3 4 5}))
+      (testing "distinct returns distinct elements of an RDD with the given number of partitions"
+        (is (= (-> (f/parallelize c [1 2 1 3 4 5 4])
+                   (f/distinct 2)
+                   f/collect
+                   vec
+                   sort)
+               [1 2 3 4 5])))
 
-      (fact
-        "take returns an array with the first n elements of an RDD"
-        (-> (f/parallelize c [1 2 3 4 5])
-            (f/take 3)) => [1 2 3])
+      (testing "take returns an array with the first n elements of an RDD"
+        (is (= (-> (f/parallelize c [1 2 3 4 5])
+                   (f/take 3))
+               [1 2 3])))
 
-      (fact
-        "glom returns an RDD created by coalescing all elements within each partition into a list"
-        (-> (f/parallelize c [1 2 3 4 5 6 7 8 9 10] 2)
-            f/glom
-            f/collect
-            vec) => (just [[1 2 3 4 5] [6 7 8 9 10]] :in-any-order))
+      (testing "glom returns an RDD created by coalescing all elements within each partition into a list"
+        (is (= (-> (f/parallelize c [1 2 3 4 5 6 7 8 9 10] 2)
+                   f/glom
+                   f/collect
+                   vec)
+               [[1 2 3 4 5] [6 7 8 9 10]])))
 
-      (fact
-        "cache persists this RDD with a default storage level (MEMORY_ONLY)"
+      (testing "cache persists this RDD with a default storage level (MEMORY_ONLY)"
         (let [cache (-> (f/parallelize c [1 2 3 4 5])
                         (f/cache))]
-          (-> cache
-              f/collect) => [1 2 3 4 5]))
+          (is (= (-> cache f/collect)
+                 [1 2 3 4 5]))))
       )))

--- a/test/flambo/conf_test.clj
+++ b/test/flambo/conf_test.clj
@@ -1,18 +1,15 @@
 (ns flambo.conf-test
-  (:use midje.sweet)
+  (:use clojure.test)
   (:require [flambo.conf :as conf]))
 
-(facts
- "about setting k/v into spark-conf"
- (let [c (conf/spark-conf)]
-   (fact
-    "spark-conf returns a SparkConf object"
-    (class c) => org.apache.spark.SparkConf)
+(deftest spark-conf
+  "about setting k/v into spark-conf"
+  (let [c (conf/spark-conf)]
+    (testing "spark-conf returns a SparkConf object"
+      (is (= (class c) org.apache.spark.SparkConf)))
 
-   (fact
-    "setting master works"
-    (conf/get (conf/master c "local") "spark.master") => "local")
+    (testing "setting master works"
+      (is (= (conf/get (conf/master c "local") "spark.master") "local")))
 
-   (fact
-    "setting app-name works"
-    (conf/get (conf/app-name c "test") "spark.app.name") => "test")))
+    (testing "setting app-name works"
+      (is (= (conf/get (conf/app-name c "test") "spark.app.name") "test")))))

--- a/test/flambo/function_test.clj
+++ b/test/flambo/function_test.clj
@@ -1,3 +1,3 @@
 (ns flambo.function-test
-  (:use midje.sweet)
+  (:use clojure.test)
   (:require [flambo.function :as func]))


### PR DESCRIPTION
First of all, I would like to thank you for Flambo. It is really good library to deal with Spark!

I have been using it for few weeks and I have noticed that our big jobs often failed due to `java.lang.OutOfMemoryError: PermGen space` in Spark's executors. This is due to the fact that 'serialize-fn' uses eval for deserialising functions which results in a lot of classes created in Spark's executors. Basically, classes are re-created for every tasks.

I looked a bit more deeply at how stuff are serialized in Flambo/Spark and I have tried another approach with this patch. I don't expect to have this PR merged in Flambo but I would like to have your opinion about it.

In short, this PR changes the way functions are serialized in Flambo. Instead of using "serialize-fn", it relies on out-of-the-box java serialization for serializing functions with theirs bindings and it also ensures that namespaces are loaded in executors. This approach works well but requires to AOT namespaces used in executors so it is not super convenient in the REPL. Another thing that I have noticed is that **my jobs are 2x faster** with this mechanism. 

In my opinion, the best solution would be to have both approaches. I mean, having the ability to define functions without AOT for developing and using AOT for running apps in production.

WDYT?

PS: Midje tests can not be AOT'ed so I switched them to clojure.test.

