### PR TITLE
Add JavaRDDLike.cartesian

### DIFF
--- a/src/clojure/flambo/api.clj
+++ b/src/clojure/flambo/api.clj
@@ -237,6 +237,12 @@
       (.reduceByKey (function2 f))
       (.map (function untuple))))
 
+(defn cartesian
+  "Creates the cartesian product of two RDDs returning an RDD of pairs"
+  [rdd1 rdd2]
+  (-> (.cartesian rdd1 rdd2)
+    (.map (function untuple))))
+
 (defn group-by
   "Returns an RDD of items grouped by the return value of function `f`."
   ([rdd f]

--- a/test/flambo/api_test.clj
+++ b/test/flambo/api_test.clj
@@ -221,6 +221,14 @@
             f/collect
             vec) => (just [0 1 2 3 4] :in-any-order))
 
+      (fact
+        "cartesian creates cartesian product of two RDDS"
+        (let [rdd1 (f/parallelize c [1 2])
+              rdd2 (f/parallelize c [5 6 7])]
+          (-> (f/cartesian rdd1 rdd2)
+            f/collect
+            vec) => (just [[1 5] [1 6] [1 7] [2 5] [2 6] [2 7]] :in-any-order)))
+
       (future-fact "repartition returns a new RDD with exactly n partitions")
 
       )))


### PR DESCRIPTION
I find the cartesian operation on two RDDs useful and it wasn't provided. This adds an implementation and test case.

https://spark.apache.org/docs/latest/api/java/org/apache/spark/api/java/JavaRDDLike.html#cartesian(org.apache.spark.api.java.JavaRDDLike)
