### PR TITLE
Basic Spark 1.3 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Flambo is a Clojure DSL for Spark. It allows you to create and manipulate Spark 
 <a name="versions">
 ## Supported Spark Versions
 
+flambo 0.6.0 targets >= Spark 1.3.0
+
 flambo 0.5.0 targets >= Spark 1.2.0
 
 flambo 0.4.0 targets >= Spark 1.1.0
@@ -46,6 +48,8 @@ Flambo is available from clojars. Depending on the version of Spark you're using
 
 ### With Leiningen
 
+`[yieldbot/flambo "0.6.0"]` for Spark 1.3.0 or greater
+
 `[yieldbot/flambo "0.5.0"]` for Spark 1.2.0 or greater
 
 `[yieldbot/flambo "0.4.0"]` for Spark 1.1.0 or greater
@@ -59,7 +63,7 @@ Don't forget to add spark (and possibly your hadoop distribution's hadoop-client
 ```clojure
 {:profiles {:provided
              {:dependencies
-              [[org.apache.spark/spark-core_2.10 "1.2.0"]]}}}
+              [[org.apache.spark/spark-core_2.10 "1.3.0"]]}}}
 ```
 
 <a name="aot">

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject yieldbot/flambo "0.5.0"
+(defproject yieldbot/flambo "0.6.0-SNAPSHOT"
   :description "A Clojure DSL for Apache Spark"
   :url "https://github.com/yieldbot/flambo"
   :license {:name "Eclipse Public License"
@@ -25,11 +25,11 @@
                     flambo.example.tfidf]}
              :provided
              {:dependencies
-              [[org.apache.spark/spark-core_2.10 "1.2.0"]
-               [org.apache.spark/spark-streaming_2.10 "1.2.0"]
-               [org.apache.spark/spark-streaming-kafka_2.10 "1.2.0"]
-               [org.apache.spark/spark-streaming-flume_2.10 "1.2.0"]
-               [org.apache.spark/spark-sql_2.10 "1.2.0"]]}
+              [[org.apache.spark/spark-core_2.10 "1.3.0"]
+               [org.apache.spark/spark-streaming_2.10 "1.3.0"]
+               [org.apache.spark/spark-streaming-kafka_2.10 "1.3.0"]
+               [org.apache.spark/spark-streaming-flume_2.10 "1.3.0"]
+               [org.apache.spark/spark-sql_2.10 "1.3.0"]]}
              :clojure-1.7
              {:dependencies [[org.clojure/clojure "1.7.0-alpha4"]]}
              :uberjar

--- a/src/clojure/flambo/sql.clj
+++ b/src/clojure/flambo/sql.clj
@@ -20,16 +20,16 @@
 (defn json-file [sql-context path]
   (.jsonFile sql-context path))
 
-(defn register-rdd-as-table [sql-context rdd table-name]
-  (.registerRDDAsTable sql-context rdd table-name))
+(defn register-data-frame-as-table [sql-context df table-name]
+  (.registerDataFrameAsTable sql-context df table-name))
 
 (defn cache-table [sql-context table-name]
   (.cacheTable sql-context table-name))
 
-;; ## JavaSchemaRDD
+;; ## DataFrame
 ;;
-(defn register-as-table [rdd table-name]
-  (.registerAsTable rdd table-name))
+(defn register-temp-table [df table-name]
+  (.registerTempTable df table-name))
 
 (def print-schema (memfn printSchema))
 

--- a/src/clojure/flambo/sql.clj
+++ b/src/clojure/flambo/sql.clj
@@ -4,13 +4,12 @@
 ;;
 (ns flambo.sql
   (:require [flambo.api :as f :refer [defsparkfn]])
-  (:import [org.apache.spark.sql.api.java JavaSQLContext Row]
-           [org.apache.spark.sql SQLContext]))
+  (:import [org.apache.spark.sql SQLContext Row]))
 
 ;; ## JavaSQLContext
 ;;
 (defn sql-context [spark-context]
-  (JavaSQLContext. spark-context))
+  (SQLContext. spark-context))
 
 (defn sql [sql-context query]
   (.sql sql-context query))
@@ -25,8 +24,7 @@
   (.registerRDDAsTable sql-context rdd table-name))
 
 (defn cache-table [sql-context table-name]
-  (let [scala-sql-context (.sqlContext sql-context)]
-    (.cacheTable scala-sql-context table-name)))
+  (.cacheTable sql-context table-name))
 
 ;; ## JavaSchemaRDD
 ;;


### PR DESCRIPTION
First PR here. I'm starting to do a lot of work with Spark SQL and would love to have full access with Flambo. The whole sql package changed a ton with the `DataFrame` API in 1.3.0. Planning to work on top of this branch, filling out the `sql.clj` file with more complete API access with tests.

Let me know if you prefer to have an all-in-one later or if just getting barebones compatibility is a start.