### PR TITLE
Serialize functions with kryo

### DIFF
--- a/src/clojure/flambo/function.clj
+++ b/src/clojure/flambo/function.clj
@@ -11,7 +11,11 @@
   (= (type f) :serializable.fn/serializable-fn))
 
 (def serialize-fn sfn/serialize)
-(def deserialize-fn (memoize sfn/deserialize))
+(def deserialize-serfn (memoize sfn/deserialize))
+(def deserialize-fn (memoize #(let [f (kryo/deserialize (first %))]
+                                (->> f class .getName (re-matches #"(.*?)\$.*")
+                                     second symbol require)
+                                f)))
 (def array-of-bytes-type (Class/forName "[B"))
 
 ;; ## Generic
@@ -24,8 +28,8 @@
   (let [fn-or-serfn (.state this)
         f (if (instance? array-of-bytes-type fn-or-serfn)
             (binding [sfn/*deserialize* kryo/deserialize]
-              (deserialize-fn fn-or-serfn))
-            fn-or-serfn)]
+              (deserialize-serfn fn-or-serfn))
+            (deserialize-fn fn-or-serfn))]
     (log/trace "CLASS" (type this))
     (log/trace "META" (meta f))
     (log/trace "XS" xs)
@@ -52,8 +56,10 @@
         :constructors {[Object] []})
        (defn ~wrapper-name [f#]
          (new ~new-class-sym
-              (if (serfn? f#) (binding [sfn/*serialize* kryo/serialize]
-                                (serialize-fn f#)) f#))))))
+              (if (serfn? f#)
+                (binding [sfn/*serialize* kryo/serialize]
+                  (serialize-fn f#))
+                [(kryo/serialize f#)]))))))
 
 (gen-function Function function)
 (gen-function Function2 function2)

--- a/src/clojure/flambo/function.clj
+++ b/src/clojure/flambo/function.clj
@@ -13,8 +13,8 @@
 (def serialize-fn sfn/serialize)
 (def deserialize-serfn (memoize sfn/deserialize))
 (def deserialize-fn (memoize #(let [f (kryo/deserialize (first %))]
-                                (->> f class .getName (re-matches #"(.*?)\$.*")
-                                     second symbol require)
+                                (when (instance? clojure.lang.Var$Unbound f)
+                                  (require (.. f v ns getName)))
                                 f)))
 (def array-of-bytes-type (Class/forName "[B"))
 


### PR DESCRIPTION
I have not seen this mentioned anywhere, but we have an if condition in `gen-function` macro which will let you pass plain function in transformations as well. So you can pass aot compiled functions directly without any problems e.g.
`(f/map inc)` and `(f/map (fn [x] (+ x x))` is completely valid if aot compiled.

This pr inhances this to serialize plain functions with kryo instead. Which has added advantage that it lets you close over locals too. It requires aot so cannot be used directly over a repl which has sc over a remote spark cluster but works fine on local spark cluster.