### PR TITLE
Remove unused imports and add imports for fully qualified Java classes

### DIFF
--- a/src/clojure/flambo/api.clj
+++ b/src/clojure/flambo/api.clj
@@ -26,9 +26,9 @@
             [flambo.kryo :as k]
             [flambo.scala-interop :as si])
   (:import [scala Tuple2]
-           [java.util Comparator]
+           [java.util Comparator ArrayList]
            [org.apache.spark.api.java JavaSparkContext StorageLevels
-            JavaRDD JavaDoubleRDD JavaPairRDD]
+            JavaRDD JavaDoubleRDD]
            [org.apache.spark.rdd PartitionwiseSampledRDD]))
 
 ;; flambo makes extensive use of kryo to serialize and deserialize clojure functions
@@ -144,7 +144,7 @@
 (defn union
   "Build the union of two or more RDDs"
   [context rdd & rdds]
-  (.union context rdd (java.util.ArrayList. rdds)))
+  (.union context rdd (ArrayList. rdds)))
 
 (defn partitionwise-sampled-rdd [rdd sampler preserve-partitioning? seed]
   "Creates a PartitionwiseSampledRRD from existing RDD and a sampler object"

--- a/src/clojure/flambo/function.clj
+++ b/src/clojure/flambo/function.clj
@@ -1,9 +1,7 @@
 (ns flambo.function
   (:require [serializable.fn :as sfn]
-            [flambo.utils :as u]
             [flambo.kryo :as kryo]
-            [clojure.tools.logging :as log])
-  (:import [scala Tuple2]))
+            [clojure.tools.logging :as log]))
 
 (set! *warn-on-reflection* false)
 

--- a/src/clojure/flambo/kryo.clj
+++ b/src/clojure/flambo/kryo.clj
@@ -1,8 +1,7 @@
 ;; ## Utilities and macros for dealing with kryo
 ;;
 (ns flambo.kryo
-  (:import [org.apache.spark.serializer KryoRegistrator]
-           [org.apache.spark SparkEnv]
+  (:import [org.apache.spark SparkEnv]
            [org.apache.spark.serializer SerializerInstance]
            [java.nio ByteBuffer]
            [scala.reflect ClassTag$]))

--- a/src/clojure/flambo/streaming.clj
+++ b/src/clojure/flambo/streaming.clj
@@ -12,7 +12,7 @@
                                      function2
                                      pair-function
                                      void-function]])
-  (:import [org.apache.spark.streaming.api.java JavaStreamingContext JavaDStream]
+  (:import [org.apache.spark.streaming.api.java JavaStreamingContext]
            [org.apache.spark.streaming.kafka KafkaUtils]
            [org.apache.spark.streaming.flume FlumeUtils]
            [org.apache.spark.streaming Duration Time]))

--- a/src/clojure/flambo/utils.clj
+++ b/src/clojure/flambo/utils.clj
@@ -1,7 +1,6 @@
 (ns flambo.utils
   (:require [clojure.tools.logging :as log])
-  (:import [scala Tuple2]
-           [org.apache.spark.util.random BernoulliCellSampler XORShiftRandom]
+  (:import [org.apache.spark.util.random BernoulliCellSampler]
            [java.io PrintStream]
            [flambo WriterOutputStream]
            [org.apache.log4j Logger WriterAppender SimpleLayout]))

--- a/test/flambo/api_test.clj
+++ b/test/flambo/api_test.clj
@@ -2,7 +2,9 @@
   (:use midje.sweet)
   (:require [flambo.api :as f]
             [flambo.tuple :as ft]
-            [flambo.conf :as conf]))
+            [flambo.conf :as conf])
+  (:import (org.apache.spark.api.java JavaSparkContext JavaRDD)
+           (scala Tuple2)))
 
 (facts
  "about spark-context"
@@ -12,11 +14,11 @@
    (f/with-context c conf
      (fact
       "gives us a JavaSparkContext"
-      (class c) => org.apache.spark.api.java.JavaSparkContext)
+      (class c) => JavaSparkContext)
 
      (fact
       "creates a JavaRDD"
-      (class (f/parallelize c [1 2 3 4 5])) => org.apache.spark.api.java.JavaRDD)
+      (class (f/parallelize c [1 2 3 4 5])) => JavaRDD)
 
      (fact
       "round-trips a clojure vector"
@@ -52,12 +54,12 @@
 
  (fact
   "untuple returns a 2 vector"
-  (let [tuple2 (scala.Tuple2. 1 "hi")]
+  (let [tuple2 (Tuple2. 1 "hi")]
     (f/untuple tuple2) => [1 "hi"]))
 
  (fact
   "double untuple returns a vector with a key and a 2 vector value"
-  (let [double-tuple2 (scala.Tuple2. 1 (scala.Tuple2. 2 "hi"))]
+  (let [double-tuple2 (Tuple2. 1 (Tuple2. 2 "hi"))]
     (f/double-untuple double-tuple2) => [1 [2 "hi"]]))
 
  (future-fact "group-untuple"))

--- a/test/flambo/conf_test.clj
+++ b/test/flambo/conf_test.clj
@@ -1,13 +1,14 @@
 (ns flambo.conf-test
   (:use midje.sweet)
-  (:require [flambo.conf :as conf]))
+  (:require [flambo.conf :as conf])
+  (:import (org.apache.spark SparkConf)))
 
 (facts
  "about setting k/v into spark-conf"
  (let [c (conf/spark-conf)]
    (fact
     "spark-conf returns a SparkConf object"
-    (class c) => org.apache.spark.SparkConf)
+    (class c) => SparkConf)
 
    (fact
     "setting master works"


### PR DESCRIPTION
Just some cleanup I ran across while working on a few features.