### PR TITLE
AOT compile

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,7 @@
                   :exclusions [com.twitter/chill-java]]
                  [com.twitter/chill_2.10 "0.5.0"
                   :exclusions [org.scala-lang/scala-library]]]
+  :aot       :all
   :profiles {:dev
              {:dependencies [[midje "1.6.3"]
                              [criterium "0.4.3"]]


### PR DESCRIPTION
When attempting to use this project as a library get error:

Exception in thread "main" java.lang.ClassNotFoundException:
flambo.function.Function, compiling:(flambo/function.clj:65:1)

Uberjar profile is not used by lein install so the clojar version does
not contain this class. Adding :aot :all to the main project map
resolved this issue.