### PR TITLE
Correct defregistrator example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Here is an Example (this won't work in your REPL):
   (:require [flambo.kryo :as kryo])
   (:import [flameprincess FlamePrincessHeat FlamePrincessHeatSerializer]))
 
-(kryo/defregistrator flameprincess [kryo]
+(kryo/defregistrator flameprincess [this kryo]
   (.register kryo FlamePrincessHeat (FlamePrincessHeatSerializer.)))
 
 (def c (-> (conf/spark-conf)

--- a/src/java/flambo/kryo/BaseFlamboRegistrator.java
+++ b/src/java/flambo/kryo/BaseFlamboRegistrator.java
@@ -29,7 +29,7 @@ public class BaseFlamboRegistrator implements KryoRegistrator {
 
 
     } catch (Exception e) {
-      throw new RuntimeException("Failed to register kryo!");
+      throw new RuntimeException("Failed to register kryo!", e);
     }
   }
 }


### PR DESCRIPTION
The macro defines a method, which needs to take in the instance (`this`) as its first parameter.  In my own code I'm using `_` instead of `this`, but maybe this is more clear.