### PR TITLE
Add save-as-text-file with the extra compression codec parameter

### DIFF
--- a/src/clojure/flambo/api.clj
+++ b/src/clojure/flambo/api.clj
@@ -419,8 +419,10 @@
   in a given directory `path` in the local filesystem, HDFS or any other Hadoop-supported
   file system. Spark will call toString on each element to convert it to a line of
   text in the file."
-  [rdd path]
-  (.saveAsTextFile rdd path))
+  ([rdd path]
+   (.saveAsTextFile rdd path))
+  ([rrd path compression-codec]
+    (.saveAsTextFile rrd path compression-codec)))
 
 (defn save-as-sequence-file
   "Writes the elements of `rdd` as a Hadoop SequenceFile in a given `path`


### PR DESCRIPTION
Thanks for this project, I'm glad to make Spark workflows using clojure :-)

Here is a small improvement regarding save-as-text-file function: saveAsTextFile can take a optional third parameter specifying the compression codec to use to save files.