### PR TITLE
Update read-csv to Spark 2.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,8 +32,7 @@
                [org.apache.spark/spark-streaming_2.11 "2.0.0"]
                [org.apache.spark/spark-streaming-kafka-0-8_2.11 "2.0.0"]
                [org.apache.spark/spark-sql_2.11 "2.0.0"]
-               [org.apache.spark/spark-hive_2.11 "2.0.0"]
-               [com.databricks/spark-csv_2.11 "1.4.0"]]}
+               [org.apache.spark/spark-hive_2.11 "2.0.0"]]}
              :clojure-1.6
              {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :uberjar

--- a/src/clojure/flambo/sql.clj
+++ b/src/clojure/flambo/sql.clj
@@ -68,7 +68,7 @@
     (.put options "header" (if header "true" "false"))
     (.put options "separator" separator)
     (.put options "quote" quote)
-    (.load sql-context "com.databricks.spark.csv" options)))
+    (-> sql-context .read (.format "csv") (.options options) .load)))
 
 (defn register-data-frame-as-table
   "Registers the given DataFrame as a temporary table in the


### PR DESCRIPTION
This commit:

- removes dependency on spark-csv (CSV input format is available out of the box in Spark 2.0).
- replaces calls to deprecated `SQLContex.load` method with `DataFrameReader`.