### PR TITLE
Clean up default values that should be symbols.

### DIFF
--- a/src/clojure/flambo/api.clj
+++ b/src/clojure/flambo/api.clj
@@ -222,7 +222,7 @@
   "Similar to `map-partitions`, but runs separately on each partition (block) of the `rdd`, so function `f`
   must be of type Iterator<T> => Iterable<scala.Tuple2<K,V>>."
   [rdd f & {:keys [preserves-partitioning]
-            :or {:preserves-partitioning false}}]
+            :or {preserves-partitioning false}}]
   (.mapPartitionsToPair rdd (pair-flat-map-function f) (u/truthy? preserves-partitioning)))
 
 (defn map-partitions-with-index

--- a/src/clojure/flambo/debug.clj
+++ b/src/clojure/flambo/debug.clj
@@ -3,8 +3,8 @@
             [clojure.tools.logging :as log]))
 
 (defn inspect [rdd name & {:keys [count? cache?]
-                           :or {:count? false
-                                :cache? false}}]
+                           :or {count? false
+                                cache? false}}]
   (let [rdd (if cache?
               (-> rdd
                   (f/cache)


### PR DESCRIPTION
Pulling this library in to a project using the clojure 1.9
has compile errors using keywords instead of symbols for default
keyword arguments.