### PR TITLE
Use correct name for csv delimiter

### DIFF
--- a/src/clojure/flambo/sql.clj
+++ b/src/clojure/flambo/sql.clj
@@ -68,12 +68,12 @@
 (defn read-csv
   "Reads a file in table format and creates a data frame from it, with cases corresponding to
   lines and variables to fields in the file. A clone of R's read.csv."
-  [sql-context path &{:keys [header separator quote schema]
-                      :or   {header false separator "," quote "'"}}]
+  [sql-context path &{:keys [header delimiter quote schema]
+                      :or   {header false delimiter "," quote "'"}}]
   (let [options (new java.util.HashMap)]
     (.put options "path" path)
     (.put options "header" (if header "true" "false"))
-    (.put options "separator" separator)
+    (.put options "delimiter" delimiter)
     (.put options "quote" quote)
     (if schema
       (-> sql-context .read (.format "csv") (.options options) (.schema schema) .load)


### PR DESCRIPTION
This change breaks the api, although it didn't work anyway.