### PR TITLE
Adding missing functionality to set-if-missing

### DIFF
--- a/src/clojure/flambo/conf.clj
+++ b/src/clojure/flambo/conf.clj
@@ -43,7 +43,7 @@
 
 (defn set-if-missing
   [conf key val]
-  (.setIfMissing key val))
+  (.setIfMissing conf key val))
 
 (defn set-executor-env
   ([conf key val]


### PR DESCRIPTION
Adding in conf that was missing from set-if-missing so that .setIfMissing will not be interacting on key.