### PR TITLE
Various SQL, api and context functionality adds

### DIFF
--- a/src/clojure/flambo/context.clj
+++ b/src/clojure/flambo/context.clj
@@ -1,0 +1,54 @@
+(ns flambo.context
+  (:import [org.apache.spark SparkContext])
+  (:require [clojure.tools.logging :as log]
+            [flambo.api :as f]
+            [flambo.conf :as conf]))
+
+(def ^:dynamic *master*
+  "Used when creating Spark contexts in [[create-context]].  This is can be a
+  URL or `yarn` for a yarn cluster.  By default this is not necessary to set as
+  long as the `spark-submit` job is given the `--deploy-mode` option."
+  nil)
+
+(def ^:dynamic *app-name*
+  "The application name given to [[create-context]]."
+  "flambo")
+
+(defonce ^:private context-inst (atom nil))
+
+(defn databricks-cluster?
+  "Return whether or not we're running in a databricks cluster."
+  []
+  (contains? (System/getProperties) "databricks.serviceName"))
+
+(defn- create-context
+  "Create a spark context using URL [*master*].  By default, this creates a
+  yarn cluster context."
+  []
+  (log/infof "creating spark context")
+  (if (databricks-cluster?)
+    (-> (SparkContext/getOrCreate)
+        f/spark-context)
+    (-> (conf/spark-conf)
+        (conf/app-name *app-name*)
+        ((if *master*
+           #(conf/master % *master*)
+           identity))
+        f/spark-context)))
+
+(defn context
+  "Return the (single) JVM Spark context.  [*master*] is the URL (defaults to a
+  yarn cluster) and used only on the first use of this function.
+
+  See [[close-context]]."
+  []
+  (swap! context-inst #(or % (create-context))))
+
+(defn close-context
+  "Stop and close and cleanup the Spark Context.
+
+  See [[context]]."
+  []
+  (let [ctx @context-inst]
+    (and ctx (.stop ctx)))
+  (reset! context-inst nil))

--- a/src/clojure/flambo/function.clj
+++ b/src/clojure/flambo/function.clj
@@ -20,7 +20,11 @@
             FilterFunction
             MapPartitionsFunction
             MapGroupsFunction
-            FlatMapGroupsFunction]))
+            FlatMapGroupsFunction]
+           [org.apache.spark.sql.api.java
+            UDF1
+            UDF2
+            UDF3]))
 
 (defn- serfn? [f]
   (= (type f) :serializable.fn/serializable-fn))
@@ -56,7 +60,7 @@
        (gen-class
         :name ~new-class-sym
         :extends flambo.function.AbstractFlamboFunction
-        :implements [~(mk-sym "org.apache.spark.api.java.function.%s" clazz)]
+        :implements [~(mk-sym (if (re-find #"^UDF" (name clazz)) "org.apache.spark.sql.api.java.%s" "org.apache.spark.api.java.function.%s") clazz)]
         :prefix ~prefix-sym
         :init ~'init
         :state ~'state
@@ -100,3 +104,6 @@
 (gen-function MapPartitionsFunction map-partitions-function)
 (gen-function MapGroupsFunction map-groups-function)
 (gen-function FlatMapGroupsFunction flat-map-groups-function)
+(gen-function UDF1 udf)
+(gen-function UDF2 udf2)
+(gen-function UDF3 udf3)

--- a/src/clojure/flambo/sql.clj
+++ b/src/clojure/flambo/sql.clj
@@ -210,21 +210,7 @@
         (recur (inc i) (conj! v (.get row i)))
         (persistent! v)))))
 
-(defsparkfn
-  ^{:doc "Coerce an `org.apache.spark.sql SparkSession.Row` objects into
-Clojure maps with each map created from its respective row."}
-  row->map [^org.apache.spark.sql.Row row]
-  (let [n (.length row)
-        schema (.schema row)
-        fields (if schema (.fieldNames schema))]
-    (loop [i 0 m (transient {})]
-      (if (< i n)
-        (recur (inc i)
-               (let [coln (if fields
-                            (nth fields i)
-                            (Integer/toString i))]
-                 (assoc! m (keyword coln) (.get row i))))
-        (persistent! m)))))
+(def row->map f/row->map)
 
 (defsparkfn
   ^{:doc "Coerce an Scala interator into a Clojure sequence"}
@@ -316,18 +302,19 @@ Clojure maps with each map created from its respective row."}
   [defs]
   (let [metadata (org.apache.spark.sql.types.Metadata/empty)]
     (->> defs
-         (map (fn [{:keys [name type nullable? array-type]
-                    :or {type :string
-                         nullable? true}}]
-                (let [json (if array-type
-                             (-> "{\"type\":\"array\",\"elementType\":\"%s\",\"containsNull\":false}"
-                                 (format (clojure.core/name array-type))
-                                 DataType/fromJson)
-                             (->> type
-                                  clojure.core/name
-                                  (format "\"%s\"")
-                                  DataType/fromJson))]
-                  (StructField. name json nullable? metadata))))
+         (clojure.core/map
+          (fn [{:keys [name type nullable? array-type]
+                :or {type :string
+                     nullable? true}}]
+            (let [json (if array-type
+                         (-> "{\"type\":\"array\",\"elementType\":\"%s\",\"containsNull\":false}"
+                             (format (clojure.core/name array-type))
+                             DataType/fromJson)
+                         (->> type
+                              clojure.core/name
+                              (format "\"%s\"")
+                              DataType/fromJson))]
+              (StructField. name json nullable? metadata))))
          (into-array StructField)
          StructType.)))
 
@@ -372,6 +359,11 @@ See [[query]] for **opts** details."
   (->> (apply query-maps url sql opts)
        f/collect
        clojure.pprint/print-table))
+
+(defn field-value
+  "Return a column value for field **column-name** for **row**."
+  [^Row row column-name]
+  (.get row (.fieldIndex row column-name)))
 
 
 (def show (memfn show))


### PR DESCRIPTION
This pull request includes:

* Scala -> Clojure recursive data type conversion
* SQL array type support for `StructType` creation
* Various other small utility functions
* Context creation/caching.

The last one I might need your help.  I broke it out into a separate namespace since it seemed to need its own or I thought you might specifically have a place for it.  I also thought you'd end up wanting to refactor it quiet a bit.

The idea here is that you only get one Spark context per JVM, so might as well store it in an `atom` and keep it around without having to create it over and over.  This esp. true since most of the initial configuration (expect the app name, which I'm open for suggestions) can be derived from the JVM environment (i.e. properties etc).