### PR TITLE
Update to support JDK-17, Scala-2.12 & Spark-3x

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject yieldbot/flambo "0.8.3-SNAPSHOT"
+(defproject yieldbot/flambo "0.9.0-SNAPSHOT"
   :description "A Clojure DSL for Apache Spark"
   :url "https://github.com/yieldbot/flambo"
   :license {:name "Eclipse Public License"
@@ -6,19 +6,15 @@
   :mailing-list {:name "flambo user mailing list"
                  :archive "https://groups.google.com/d/forum/flambo-user"
                  :post "flambo-user@googlegroups.com"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/tools.logging "0.3.1"]
-                 [com.google.guava/guava "18.0"]
-                 [yieldbot/serializable-fn "0.1.2"
-                  :exclusions [com.twitter/chill-java]]
-                 [com.twitter/carbonite "1.5.0"
-                  :exclusions [com.twitter/chill-java]]
-                 [com.twitter/chill_2.11 "0.8.0"
-                  :exclusions [org.scala-lang/scala-library]]]
+  :dependencies [[org.clojure/clojure "1.12.0"]
+                 [org.clojure/tools.logging "1.3.0"]
+                 [com.google.guava/guava "33.4.6-jre"]
+                 [yieldbot/serializable-fn "0.1.3"
+                  :exclusions [com.twitter/chill-java]]]
   :profiles {:dev
-             {:dependencies [[midje "1.6.3"]
+             {:dependencies [[midje "1.10.10"]
                              [criterium "0.4.3"]]
-              :plugins [[lein-midje "3.1.3"]
+              :plugins [[lein-midje "3.2.1"]
                         [michaelblume/lein-marginalia "0.9.0"]
                         ;; [codox "0.8.9"]
                         [funcool/codeina "0.3.0"
@@ -28,11 +24,39 @@
                     flambo.example.tfidf]}
              :provided
              {:dependencies
-              [[org.apache.spark/spark-core_2.11 "2.3.1"]
-               [org.apache.spark/spark-streaming_2.11 "2.3.1"]
-               [org.apache.spark/spark-streaming-kafka-0-10_2.11 "2.3.1"]
-               [org.apache.spark/spark-sql_2.11 "2.3.1"]
-               [org.apache.spark/spark-hive_2.11 "2.3.1"]]}
+              [[com.fasterxml.jackson.core/jackson-core "2.15.2"]
+               [org.slf4j/slf4j-api "2.0.7"]
+               [org.apache.spark/spark-core_2.12 "3.5.1"
+                :exclusions [[com.google.code.findbugs/jsr305]
+                             [com.google.code.gson/gson]
+                             [com.google.protobuf/protobuf-java]
+                             [com.fasterxml.jackson.core/jackson-core]
+                             [org.slf4j/slf4j-api]
+                             [commons-logging]]]
+               [org.apache.spark/spark-streaming_2.12 "3.5.1"
+                :exclusions [[com.google.code.findbugs/jsr305]
+                             [com.google.code.gson/gson]
+                             [com.google.protobuf/protobuf-java]
+                             [org.slf4j/slf4j-api]]]
+               [org.apache.spark/spark-streaming-kafka-0-10_2.12 "3.5.1"]
+               [org.apache.spark/spark-sql_2.12 "3.5.1"
+                :exclusions [[com.google.code.findbugs/jsr305]
+                             [com.google.code.gson/gson]
+                             [com.google.protobuf/protobuf-java]
+                             [org.apache.yetus/audience-annotations]
+                             [org.slf4j/slf4j-api]]]
+               [org.apache.spark/spark-hive_2.12 "3.5.1"
+                :exclusions [[com.google.code.findbugs/jsr305]
+                             [com.google.code.gson/gson]
+                             [com.google.protobuf/protobuf-java]
+                             [org.apache.yetus/audience-annotations]
+                             [org.slf4j/slf4j-api]
+                             [commons-logging]]]
+               [org.apache.spark/spark-catalyst_2.12 "3.5.1"
+                :exclusions [[com.google.code.findbugs/jsr305]
+                             [com.google.code.gson/gson]
+                             [com.google.protobuf/protobuf-java]
+                             [org.slf4j/slf4j-api]]]]}
              :clojure-1.6
              {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :clojure-1.7
@@ -57,7 +81,13 @@
           :output-dir "doc/codox"
           :src-dir-uri "http://github.com/yieldbot/flambo/blob/develop/"
           :src-linenum-anchor-prefix "L"}
-  :javac-options ["-source" "1.8" "-target" "1.8"]
-  :jvm-opts ^:replace ["-server" "-Xmx2g"]
+  :jvm-opts ["-server" "-Xmx2g"
+             "-Duser.language=en"
+             "--add-opens=java.base/java.io=ALL-UNNAMED"
+             "--add-opens=java.base/java.nio=ALL-UNNAMED"
+             "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
+             "--add-opens=java.base/java.util=ALL-UNNAMED"
+             "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+             "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED"]
   :global-vars {*warn-on-reflection* false}
   :min-lein-version "2.5.0")

--- a/src/clojure/flambo/accumulator.clj
+++ b/src/clojure/flambo/accumulator.clj
@@ -1,21 +1,49 @@
 (ns flambo.accumulator
-  (:import [org.apache.spark Accumulator]
-           [scala.Option])
+  (:import [org.apache.spark.util AccumulatorV2]
+           [org.apache.spark.api.java JavaSparkContext]
+           [scala Option])
   (:refer-clojure :exclude [name]))
 
-(defn accumulator
+(defn long-accumulator
+  "Creates longAccumulator and adds the value"
   ([sc value]
-   (.accumulator sc value))
+   (as-> (.longAccumulator (JavaSparkContext/toSparkContext sc)) $
+     (do (.add $ value) $)))
   ([sc value name]
-   (.accumulator sc value name)))
+   (as-> (.longAccumulator (JavaSparkContext/toSparkContext sc) name) $
+     (do (.add $ value) $))))
 
-(defn value [^Accumulator accumulator-var]
+(defn double-accumulator
+  "Creates doubleAccumulator and adds the value"
+  ([sc value]
+   (as-> (.doubleAccumulator (JavaSparkContext/toSparkContext sc)) $
+     (do (.add $ value) $)))
+  ([sc value name]
+   (as-> (.doubleAccumulator (JavaSparkContext/toSparkContext sc) name) $
+     (do (.add $ value) $))))
+
+(defn coll-accumulator
+  "Creates collectionAccumulator and adds the value"
+  ([sc value]
+   (as-> (.collectionAccumulator (JavaSparkContext/toSparkContext sc)) $
+     (do (.add $ value) $)))
+  ([sc value name]
+   (as-> (.collectionAccumulator (JavaSparkContext/toSparkContext sc) name) $
+     (do (.add $ value) $))))
+
+(defn value
+  "Returns the value of Accumulator"
+  [^AccumulatorV2 accumulator-var]
   (.value accumulator-var))
 
-(defn add [^Accumulator accumulator-var value]
-  (.add accumulator-var (int value)))
-
-(defn name [^Accumulator accumulator-var]
+(defn name
+  "Returns the name of Accumulator"
+  [^AccumulatorV2 accumulator-var]
   (let [name-var (.name accumulator-var)]
     (if (= scala.Some (class name-var))
-      (.x name-var))))
+      (.get name-var))))
+
+(defn add
+  "Add the value to Accumulator"
+  [^AccumulatorV2 accumulator-var value]
+  (.add accumulator-var value))

--- a/src/clojure/flambo/api.clj
+++ b/src/clojure/flambo/api.clj
@@ -255,8 +255,8 @@
   "Union `rdd` and `other`, or multiple RDDs. Duplicate keys are kept."
   ([rdd other]
    (.union rdd other))
-  ([context rdd & rdds]
-   (.union context rdd (ArrayList. rdds))))
+  ([rdd other & rdds]
+   (clojure.core/reduce #(union %1 %2) (union rdd other) rdds)))
 
 (defn foreach
   "Applies the function `f` to all elements of `rdd`."

--- a/src/clojure/flambo/sql.clj
+++ b/src/clojure/flambo/sql.clj
@@ -16,14 +16,13 @@
                                      flat-map-groups-function]])
 
       (:import [org.apache.spark.api.java JavaSparkContext]
-           [org.apache.spark.sql.types StructType StructField DataType StringType]
-           [org.apache.spark.sql SparkSession SQLContext Row RowFactory Dataset Column KeyValueGroupedDataset]
-           [org.apache.spark.sql.catalyst.encoders RowEncoder]
-           [org.apache.spark.sql.catalyst.expressions GenericRowWithSchema]
-           [org.apache.spark.sql.hive HiveContext]
-           [org.apache.spark.sql.expressions Window]
-           [org.apache.spark.sql.types DataTypes]
-           [org.apache.spark.sql Encoder Encoders]))
+               [org.apache.spark.sql.types StructType StructField DataType StringType]
+               [org.apache.spark.sql SparkSession SQLContext Row RowFactory Dataset Column KeyValueGroupedDataset]
+               [org.apache.spark.sql.catalyst.expressions GenericRowWithSchema]
+               [org.apache.spark.sql.hive HiveContext]
+               [org.apache.spark.sql.expressions Window]
+               [org.apache.spark.sql.types DataTypes]
+               [org.apache.spark.sql SparkSession Encoder Encoders]))
 
 ;; ## SQLContext
 
@@ -73,8 +72,11 @@
   ([sql-context path source-type]       ; specify data source type
    (.load sql-context path source-type)))
 
-(defn create-custom-schema [array]
-  (-> (clojure.core/map #(DataTypes/createStructField (first %) (second %) (nth % 2))  array)
+(defn create-custom-schema
+  "Creates custom schema given clojure collection of
+  [[<field1> <DataType> <nullable?>] [<field2> <DataType> <nullable?>]]"
+  [array]
+  (-> (clojure.core/map #(DataTypes/createStructField (first %) (second %) (nth % 2)) array)
       DataTypes/createStructType))
 
 (defn read-csv
@@ -230,7 +232,7 @@ Clojure maps with each map created from its respective row."}
   ^{:doc "Coerce an Scala interator into a Clojure sequence"}
   iteratable-to-seq [i]
   (-> (.iterator i)
-      scala.collection.JavaConversions/asJavaIterator
+      scala.collection.JavaConverters/asJavaIterator
       iterator-seq))
 
 (defsparkfn
@@ -329,7 +331,7 @@ Clojure maps with each map created from its respective row."}
 (defn row-encoder
   "Return a row encoder with a `StructType` created with [[struct-type]]."
   [^StructType struct]
-  (RowEncoder/apply struct))
+  (Encoders/row struct))
 
 (defn create-row
   "Create a `org.apache.spark.sql SparkSession.Row` instance from a Clojure
@@ -368,10 +370,30 @@ See [[query]] for **opts** details."
        f/collect
        clojure.pprint/print-table))
 
+(defn show
+  "Shows the Dataset with options"
+  ([^Dataset df]
+   (show df false))
+  ([^Dataset df truncate?]
+   (.show df truncate?))
+  ([^Dataset df limit truncate?]
+   (.show df limit truncate?))
+  ([^Dataset df limit vertical? truncate?]
+   (.show df limit vertical? truncate?)))
 
-(def show (memfn show))
+(defn show-limit
+  "Shows the Dataset without truncating with limit"
+  [^Dataset df limit]
+  (show df limit false))
+
+(defn show-vertical
+  "Shows the Dataset without truncating with limit vertically"
+  [^Dataset df limit]
+  (show df limit 0 false))
 
 (def count (memfn count))
+
+(def collect (memfn collectAsList))
 
 (def create-global-temp-view (memfn createGlobalTempView))
 
@@ -401,11 +423,11 @@ See [[query]] for **opts** details."
   * :long
   * :string-tuple"
   [type-]
-  (cond (instance? java.lang.Class type-) (Encoders/javaSerialization type-)
+  (cond (instance? java.lang.Class type-) (Encoders/kryo type-)
         (instance? Encoder type-) type-
         (keyword? type-)
         (case type-
-          :object (Encoders/javaSerialization java.io.Serializable)
+          :object (Encoders/kryo java.io.Serializable)
           :string (Encoders/STRING)
           :boolean (Encoders/BOOLEAN)
           :byte (Encoders/BYTE)
@@ -418,6 +440,13 @@ See [[query]] for **opts** details."
           :string-tuple (Encoders/tuple (Encoders/STRING) (Encoders/STRING)))
         :else (throw (ex-info (format "Invalid encoder option: %s" type-)
                               {:type type-}))))
+
+(defn create-dataset
+  "Creates Dataset for local collections"
+  ([^SparkSession spss col]
+  (create-dataset spss :object col))
+  ([^SparkSession spss type- col]
+   (.createDataset spss col (encoder-for-type type-))))
 
 (defn ^Dataset map
   "Returns a new dataframe formed by passing each element of the source through

--- a/src/clojure/flambo/streaming.clj
+++ b/src/clojure/flambo/streaming.clj
@@ -3,6 +3,10 @@
 ;; This is a partial and mostly untested implementation of
 ;; Spark Streaming; consider it a work in progress.
 ;;
+;; Deprecated.
+;; This is deprecated as of Spark 3.4.0.
+;; There are no longer updates to DStream and it's a legacy project.
+;; https://spark.apache.org/docs/3.5.1/api/java/org/apache/spark/streaming/StreamingContext.html
 (ns flambo.streaming
   (:refer-clojure :exclude [map time print union count])
   (:require [flambo.api :as f]
@@ -14,7 +18,7 @@
                                      void-function
                                      void-function2]])
   (:import [org.apache.spark.streaming.api.java JavaStreamingContext]
-           [org.apache.spark.streaming.kafka KafkaUtils]
+           [org.apache.spark.streaming.kafka010 KafkaUtils]
            [org.apache.spark.streaming Duration Time]))
 
 (defn duration [ms]
@@ -44,11 +48,8 @@
 (defn socket-text-stream [context ip port]
   (.socketTextStream context ip port))
 
-(defn kafka-stream [streaming-context zk-connect group-id topic-map]
-  (KafkaUtils/createStream streaming-context zk-connect group-id (into {} (for [[k v] topic-map] [k (Integer. v)]))))
-
-(defn kafka-direct-stream [streaming-context key-class value-class key-decoder-class value-decoder-class kafka-params topic-set]
-  (KafkaUtils/createDirectStream streaming-context key-class value-class key-decoder-class value-decoder-class kafka-params topic-set))
+(defn kafka-direct-stream [streaming-context location-strategies consumer-strategies]
+  (KafkaUtils/createDirectStream streaming-context location-strategies consumer-strategies))
 
 (defn flat-map [dstream f]
   (.flatMap dstream (flat-map-function f)))

--- a/src/java/flambo/kryo/BaseFlamboRegistrator.java
+++ b/src/java/flambo/kryo/BaseFlamboRegistrator.java
@@ -9,7 +9,7 @@ import scala.Tuple3;
 import com.twitter.chill.Tuple2Serializer;
 import com.twitter.chill.Tuple3Serializer;
 import org.apache.spark.broadcast.Broadcast;
-import org.apache.spark.Accumulator;
+import org.apache.spark.util.AccumulatorV2;
 
 public class BaseFlamboRegistrator implements KryoRegistrator {
 
@@ -23,7 +23,7 @@ public class BaseFlamboRegistrator implements KryoRegistrator {
       kryo.register(Tuple2.class, new Tuple2Serializer());
       kryo.register(Tuple3.class, new Tuple3Serializer());
       kryo.register(Broadcast.class, new JavaSerializer());
-      kryo.register(Accumulator.class, new JavaSerializer());
+      kryo.register(AccumulatorV2.class, new JavaSerializer());
 
       register(kryo);
 

--- a/test/flambo/accumulator_test.clj
+++ b/test/flambo/accumulator_test.clj
@@ -7,17 +7,17 @@
 (facts
  "about accumulators"
   (let [conf (-> (conf/spark-conf)
-                 (conf/master "local")
+                 (conf/master "local[*]")
                  (conf/app-name "accumulator-test"))]
     (f/with-context c conf
       (facts "about basic accumulation"
-        (let [acc (a/accumulator c 0)
-              named-acc (a/accumulator c 0 "my-acc")
-              rdd (f/parallelize c (range 21))]
+        (let [acc (a/long-accumulator c (long 0))
+              named-acc (a/long-accumulator c (long 0) "my-acc")
+              rdd (f/parallelize c (map long (range 21)))]
           (fact "acc should be 210"
-            (f/foreach rdd (f/fn [x] (a/add acc x)))
+            (f/foreach rdd (f/fn [x] (a/add acc (long x))))
             (a/value acc) => 210)
           (fact "named-acc should be 210 and have a name"
-            (f/foreach rdd (f/fn [x] (a/add named-acc x)))
+            (f/foreach rdd (f/fn [x] (a/add named-acc (long x))))
             (a/value named-acc) => 210
             (a/name named-acc) => "my-acc"))))))

--- a/test/flambo/api_test.clj
+++ b/test/flambo/api_test.clj
@@ -37,7 +37,7 @@
       (let [rdd1 (f/parallelize c [1 2 3 4])
             rdd2 (f/parallelize c [21 22 23])
             rdd3 (f/parallelize c [31 32 33])]
-        (-> (f/union c rdd1 rdd2 rdd3)
+        (-> (f/union rdd1 rdd2 rdd3)
             f/collect
             vec) => (just [1 2 3 4 21 22 23 31 32 33] :in-any-order))))))
 
@@ -276,7 +276,7 @@
                  rdd2 (f/parallelize c [5 6 7])
                  rdd3 (f/parallelize c [8 9 10 11])
                  rdd4 (f/parallelize c [12 13])]
-             (-> (f/union c rdd1 rdd2 rdd3 rdd4)
+             (-> (f/union rdd1 rdd2 rdd3 rdd4)
                  (f/repartition 4)
                  f/partition-count) => 4))
 


### PR DESCRIPTION
Update to support `Spark 3x`, `JDK-17` & `Scala 2.12`

**Changes Proposed:**
- Update in major version of the project
- Upgrade Clojure to latest 1.12.0
- Upgrade Spark to 3.5.1
- Relevant JVM options updated
- Update to support `org.apache.spark.utilAccumulatorV2`
- Update to use `scala.collection.JavaConverters`
- Use `Encoders/kryo` for Dataset by default
- Include `create-dataset` function similar to RDD `parallelize`
- Update in RDD `union` function
- Update `sql` namespace to use latest spark methods & Classes
- Deprecation notice for streaming functions & namespace
- Remove `kafka-stream` function from `streaming` namespace, as `KafkaUtils/createStream` is unsupported
- Update test cases
- Remove javac options

**Related PR:**
Built on top of the changes suggested in the below PR
https://github.com/sorenmacbeth/serializable-fn/pull/3